### PR TITLE
feat: add a new 'collabora_version' variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ Note that SSL included in Collabora is deactivated and should be configured in y
 ## Role Variables
 
 
-| Name                   | Required/Default      | Description                             |
-|:-----------------------|:---------------------:|:----------------------------------------|
-| `collabora_domain`     | :heavy_check_mark:    | Domain where your nextcloud is running  |
-| `collabora_servername` | :heavy_check_mark:    | Domain the collabora instance runs on   |
-| `collabora_password`   | :heavy_check_mark:    | Password for the Collabora Admin        |
-| `collabora_username`   | `collabora_admin`     | Admin user for the web interface        |
+| Name                   | Required/Default   | Description                            |
+|:-----------------------|:------------------:|:---------------------------------------|
+| `collabora_domain`     | :heavy_check_mark: | Domain where your nextcloud is running |
+| `collabora_servername` | :heavy_check_mark: | Domain the collabora instance runs on  |
+| `collabora_password`   | :heavy_check_mark: | Password for the Collabora Admin       |
+| `collabora_username`   | `collabora_admin`  | Admin user for the web interface       |
+| `collabora_version`    | `6.4`              | The version of collabora to install    |
 
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@ Note that SSL included in Collabora is deactivated and should be configured in y
 ## Role Variables
 
 
-| Name                   | Required/Default   | Description                            |
-|:-----------------------|:------------------:|:---------------------------------------|
-| `collabora_domain`     | :heavy_check_mark: | Domain where your nextcloud is running |
-| `collabora_servername` | :heavy_check_mark: | Domain the collabora instance runs on  |
-| `collabora_password`   | :heavy_check_mark: | Password for the Collabora Admin       |
-| `collabora_username`   | `collabora_admin`  | Admin user for the web interface       |
-| `collabora_version`    | `6.4`              | The version of collabora to install    |
+| Name                     | Required/Default   | Description                                                                      |
+|:-------------------------|:------------------:|:---------------------------------------------------------------------------------|
+| `collabora_domain`       | :heavy_check_mark: | Domain where your nextcloud is running                                           |
+| `collabora_servername`   | :heavy_check_mark: | Domain the collabora instance runs on                                            |
+| `collabora_password`     | :heavy_check_mark: | Password for the Collabora Admin                                                 |
+| `collabora_username`     | `collabora_admin`  | Admin user for the web interface                                                 |
+| `collabora_version`      | `6.4`              | The version of collabora to install                                              |
+| `collabora_extra_params` | `{}`               | Configure extra collabora system parameters. Use a dot separated string as keys. |
 
 
 ## Example
@@ -26,6 +27,8 @@ collabora:
     collabora_username: admin
     collabora_password: YourPassword
     collabora_servername: collabora.example.de
+    collabora_extra_params:
+      'welcome.enable': false
 ```
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 collabora_username: collabora_admin
 collabora_version: 6.4
+collabora_extra_params: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 collabora_username: collabora_admin
+collabora_version: 6.4

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,8 +15,8 @@
     name:
       - loolwsd
       - code-brand
-      - collaboraoffice6.0-dict*
-      - collaboraofficebasis6.0*
+      - collaboraoffice{{ collabora_version }}-dict*
+      - collaboraofficebasis{{ collabora_version }}*
       - inotify-tools
       - psmisc
       - python-lxml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -91,6 +91,13 @@
     xpath: /config/server_name
     value: "{{ collabora_servername }}"
 
+- name: Set extra parameters
+  xml:
+    path: /etc/loolwsd/loolwsd.xml
+    xpath: "/{{ '/'.join(item.key.split('.')) }}"
+    value: "{{ item.value }}"
+  loop: "{{ collabora_extra_params | dict2items }}"
+
 - name: Install systemd service file (collabora.service)
   template:
     dest: /etc/systemd/system/collabora.service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,14 +2,15 @@
 - name: Add Collabora repo key
   apt_key:
     keyserver: keyserver.ubuntu.com
-    id: 6CCEA47B2281732DF5D504D00C54D189F4BA284D
+    id: "{{ item }}"
+  loop:
+    - 0C54D189F4BA284D
 
 - name: Add Collabora repos
   apt_repository:
     repo: "{{ item }}"
   loop:
-    - deb https://collaboraoffice.com/repos/CollaboraOnline/CODE /
-    - deb http://security.ubuntu.com/ubuntu xenial-security main     # Leave this here! libpng12-0 is no longer available on newer Ubuntu versions, but loolwsd won't install without it
+    - deb https://www.collaboraoffice.com/repos/CollaboraOnline/CODE-{{ ansible_distribution|lower }}{{ ansible_distribution_major_version }} ./
 
 - name: Install all needed packages for collabora online
   apt:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,6 +42,18 @@
     xpath: /config/storage/wopi/host[1]
     value: "{{ collabora_domain }}"
 
+- name: Disable Nextcloud SSL encryption # use SSL provided by nginx instead
+  xml:
+    path: /etc/loolwsd/loolwsd.xml
+    xpath: /config/storage/ssl/enable
+    value: "false"
+
+- name: Enable Nextcloud SSL termination at proxy level # use SSL provided by nginx instead
+  xml:
+    path: /etc/loolwsd/loolwsd.xml
+    xpath: /config/storage/ssl/termination
+    value: "true"
+
 - name: Set admin username
   xml:
     path: /etc/loolwsd/loolwsd.xml
@@ -53,6 +65,12 @@
     path: /etc/loolwsd/loolwsd.xml
     xpath: /config/ssl/enable
     value: "false"
+
+- name: Enable Collabora SSL termination at proxy level # use SSL provided by nginx instead
+  xml:
+    path: /etc/loolwsd/loolwsd.xml
+    xpath: /config/ssl/termination
+    value: "true"
 
 - name: Replace trusted host
   xml:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Add Collabora repo key
   apt_key:
+    keyserver: keyserver.ubuntu.com
     id: 6CCEA47B2281732DF5D504D00C54D189F4BA284D
 
 - name: Add Collabora repos

--- a/templates/collabora.service
+++ b/templates/collabora.service
@@ -4,7 +4,7 @@ Description=LibreOffice Online WebSocket Daemon for Collabora
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/loolwsd --version --o:sys_template_path=/opt/lool/systemplate --o:lo_template_path=/opt/collaboraoffice6.0 --o:child_root_path=/tmp/child-roots --o:file_server_root_path=/usr/share/loolwsd
+ExecStart=/usr/bin/loolwsd --version --o:sys_template_path=/opt/lool/systemplate --o:lo_template_path=/opt/collaboraoffice{{ collabora_version }} --o:child_root_path=/tmp/child-roots --o:file_server_root_path=/usr/share/loolwsd
 AmbientCapabilities=CAP_SYS_CHROOT CAP_SYS_MKNOD CAP_MKNOD CAP_FOWNER
 User=lool
 KillMode=control-group


### PR DESCRIPTION
This new variable helps to install a different collabora online
version when needed. The version installed from the role used to be
6.0 now the default is 6.4.